### PR TITLE
Merge schedule data from two separated feeds

### DIFF
--- a/build.py
+++ b/build.py
@@ -1,47 +1,57 @@
 import json
 import os
 import subprocess
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 import pytz
 import requests
+
+FOLDER_NAME = "ngtv-v1"
+GITHUB_REPOSITORY = os.environ.get('GITHUB_REPOSITORY', "SerCom-KC/cartoon-network-schedule")
 
 if __name__ == "__main__":
     s = requests.Session()
 
     schedule = {}
 
-    response = s.get(
-        "https://time.ngtv.io/v1/rundown",
-        params={
-            "instance": "as-east",
-            "startTime": int((datetime.now() - timedelta(days=14)).timestamp()),
-            "endTime": 2147483647
-        },
-        timeout=30
-    ).json()
     manifest = {
-        "updated": int(response["timeUTC"]),
-    "data": []
+        "updated": 0,
+        "data": []
     }
 
-    for show in response["shows"]:
-        time = datetime.utcfromtimestamp(show["guide_timestamp"]).replace(
-            tzinfo=pytz.timezone("UTC")).astimezone(tz=pytz.timezone("US/Eastern"))
-        date_string = time.strftime("%Y-%m-%d")
-        if date_string not in schedule:
-            schedule[date_string] = [show]
-        else:
-            schedule[date_string].append(show)
+    for instance in ["as-east", "cn-east"]:
+        response = s.get(
+            "https://time.ngtv.io/v1/rundown",
+            params={
+                "instance": instance,
+                #"startTime": int(datetime(year=2024, month=7, day=30, tzinfo=pytz.timezone("US/Eastern")).timestamp()),
+                "startTime": int((datetime.now() - timedelta(days=14)).timestamp()),
+                "endTime": 2147483647
+            },
+            timeout=30
+        ).json()
+
+        updated = int(response["timeUTC"])
+        if updated > manifest["updated"]:
+            manifest["updated"] = updated
+
+        for show in response["shows"]:
+            time = datetime.fromtimestamp(show["guide_timestamp"], tz=timezone.utc).replace(
+                tzinfo=timezone.utc).astimezone(tz=pytz.timezone("US/Eastern"))
+            date_string = time.strftime("%Y-%m-%d")
+            if date_string not in schedule:
+                schedule[date_string] = [show]
+            else:
+                schedule[date_string].append(show)
 
     del(schedule[list(schedule)[0]])
 
     for date in schedule.keys():
-        with open("ngtv-v1/" + date, "w+") as file:
-            file.write(json.dumps(schedule[date], indent=4))
+        with open(os.path.join(FOLDER_NAME, date), "w+") as file:
+            file.write(json.dumps(sorted(schedule[date], key=lambda x: x["guide_timestamp"]), indent=4))
         manifest["data"].append(
-            {"date": date, "url": "https://github.com/%s/raw/ngtv-v1/%s" % (os.environ['GITHUB_REPOSITORY'], date)})
+            {"date": date, "url": "https://github.com/%s/raw/ngtv-v1/%s" % (GITHUB_REPOSITORY, date)})
 
-    if subprocess.run(["git", "status", "--porcelain"], cwd="ngtv-v1", stdout=subprocess.PIPE).stdout != b"":
-        with open("ngtv-v1/manifest", "w+") as file:
+    if subprocess.check_output(["git", "status", "--porcelain"], cwd=FOLDER_NAME) != b"":
+        with open(os.path.join(FOLDER_NAME, "manifest"), "w+") as file:
             file.write(json.dumps(manifest, indent=4))


### PR DESCRIPTION
Schedule data of Cartoon Network and Adult Swim get separated starting August 1, 2024.
Since this date, schedules of Cartoon Network should be fetched with `instance` set to `cn-east` (or `cn-west` for the western feed).

Fixes #1